### PR TITLE
Enhance security, optimize CI, improve documentation, and add Terrafo…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
 
       - name: Install Terraform
         run: |
+          sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          sudo apt-add-repository "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
           sudo apt-get update && sudo apt-get install -y terraform
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          sudo apt-add-repository "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
           sudo apt-get update && sudo apt-get install -y terraform
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,8 @@ jobs:
 
       - name: Install OpenTofu
         run: |
-          curl -Lo ./tofu.tar.gz https://github.com/opentofu/opentofu/releases/latest/download/tofu_linux_amd64.tar.gz
-          tar -xzf tofu.tar.gz
-          chmod +x tofu
-          sudo mv tofu /usr/local/bin/
+          curl -Lo ./tofu.deb https://github.com/opentofu/opentofu/releases/download/v1.8.2/tofu_1.8.2_amd64.deb
+          sudo dpkg -i ./tofu.deb
         shell: bash
 
       - name: Install Terraform

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           else
             echo "Both test suites failed."
             exit 1  # Exit with failure
+          fi  # Ensure fi closes the if block
         shell: bash
 
   security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,30 +7,49 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code }}
+      test_changed: ${{ steps.filter.outputs.test }}
+      terraform_changed: ${{ steps.filter.outputs.terraform }}
+      docs_changed: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Filter files
+        id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - '**/*.go'
+            test:
+              - 'test/**'
+            terraform:
+              - '**/*.tf'
+              - 'tofu/**'
+            docs:
+              - '**/*.md'
+              - 'docs/**'
+
   test:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true' || needs.changes.outputs.test_changed == 'true'
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: us-west-2
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.21'
-      - name: Set up OpenTofu
-        uses: opentofu/setup-opentofu@v1
-      - name: Install tflint
-        run: |
-          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
-      - name: Install terraform-docs
-        run: |
-          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-linux-amd64.tar.gz
-          tar -xzf terraform-docs.tar.gz
-          chmod +x terraform-docs
-          sudo mv terraform-docs /usr/local/bin/
-          rm terraform-docs.tar.gz
+
       - name: Run tests
         run: |
           cd test
@@ -38,8 +57,11 @@ jobs:
 
   security:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.terraform_changed == 'true'
     steps:
       - uses: actions/checkout@v4
+
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/iac@master
         env:
@@ -47,6 +69,7 @@ jobs:
         with:
           command: test
           args: ./tofu
+
       - name: Run tfsec
         uses: aquasecurity/tfsec-action@v1.0.0
         with:
@@ -55,33 +78,41 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    needs: changes
     steps:
       - uses: actions/checkout@v4
+
       - name: Run golangci-lint
+        if: needs.changes.outputs.code_changed == 'true'
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: test
+
       - name: Run markdown lint
+        if: needs.changes.outputs.docs_changed == 'true'
         uses: avto-dev/markdown-lint@v1
         with:
           config: '.markdownlint.json'
           args: '**/*.md'
-  
+
   deploy-docs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [test, security, lint]
-    if: github.ref == 'refs/heads/main'
+    needs: [test, security, lint, changes]
+    if: github.ref == 'refs/heads/main' && needs.changes.outputs.docs_changed == 'true'
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+
       - name: Install dependencies
         run: |
           pip install mkdocs
+
       - name: Build and deploy documentation
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,48 @@ jobs:
         with:
           go-version: '1.21'
 
-      - name: Run tests
+      - name: Install OpenTofu
         run: |
+          curl -Lo ./tofu.tar.gz https://github.com/opentofu/opentofu/releases/latest/download/tofu_linux_amd64.tar.gz
+          tar -xzf tofu.tar.gz
+          chmod +x tofu
+          sudo mv tofu /usr/local/bin/
+        shell: bash
+
+      - name: Install Terraform
+        run: |
+          sudo apt-get update && sudo apt-get install -y terraform
+        shell: bash
+
+      - name: Run OpenTofu Tests
+        id: tofu-tests
+        continue-on-error: true  # Continue even if this test fails
+        run: |
+          export TERRATEST_TERRAFORM_EXECUTABLE=tofu
           cd test
           go test -v ./...
+        shell: bash
+
+      - name: Run Terraform Tests
+        id: terraform-tests
+        continue-on-error: true  # Continue even if this test fails
+        run: |
+          export TERRATEST_TERRAFORM_EXECUTABLE=terraform
+          cd test
+          go test -v ./...
+        shell: bash
+
+      - name: Determine Final Status
+        if: always()  # Always run this step
+        run: |
+          # Check if either test passed
+          if [[ "${{ steps.tofu-tests.outcome }}" == "success" || "${{ steps.terraform-tests.outcome }}" == "success" ]]; then
+            echo "At least one test suite passed."
+            exit 0  # Exit with success
+          else
+            echo "Both test suites failed."
+            exit 1  # Exit with failure
+        shell: bash
 
   security:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # Harbor on EKS: Streamlined Deployment for Vulnerability Scanning
 
-Easily deploy Harbor, an open-source container registry and vulnerability scanning platform, on Amazon EKS using OpenTofu.
+> **Coming Soon**: We're excited to announce that our next major update will focus on modularizing the OpenTofu configuration. This will make it even easier to customize and use different components of the code independently, allowing for more flexible and tailored deployments. Stay tuned for a more adaptable and scalable Harbor on EKS solution!
+
+Easily deploy Harbor, an open-source container registry and vulnerability scanning platform, on Amazon EKS using OpenTofu or Terraform.
 
 ## Features and Benefits
 
-- **Effortless Deployment**: Get a production-ready Harbor up and running on Amazon EKS with just a few commands
-- **Scalable Architecture**: Uses EFS (Elastic File System) for persistent storage, allowing easy growth
-- **Secure Configuration**: Utilizes RDS for a robust and secure database backend
-- **Smart Load Balancing**: Implements AWS Load Balancer Controller for smooth traffic management
-- **Comprehensive Testing**: Includes a test suite and CI/CD integration for reliability
-- **Budget-Friendly**: Efficiently uses AWS services to optimize costs
-- **Customizable**: Easily adaptable to fit your organization's unique needs
-- **Best Practices Baked In**: Implements AWS and Kubernetes best practices right out of the box
+- **Effortless Deployment**: Get a production-ready Harbor up and running on Amazon EKS with just a few commands.
+- **Scalable Architecture**: Uses EFS (Elastic File System) for persistent storage, allowing easy growth.
+- **Secure Configuration**: Utilizes RDS for a robust and secure database backend.
+- **Smart Load Balancing**: Implements AWS Load Balancer Controller for smooth traffic management.
+- **Comprehensive Testing**: Includes a test suite and CI/CD integration for reliability.
+- **Budget-Friendly**: Efficiently uses AWS services to optimize costs.
+- **Customizable**: Easily adaptable to fit your organization's unique needs.
+- **Best Practices Baked In**: Implements AWS and Kubernetes best practices right out of the box.
 
 ## Quick Start
 
@@ -19,7 +21,7 @@ Easily deploy Harbor, an open-source container registry and vulnerability scanni
 
 Before you begin, ensure you have the following installed:
 
-- [OpenTofu](https://opentofu.org/docs/intro/install/) >= 1.8.0
+- [OpenTofu](https://opentofu.org/docs/intro/install/) >= 1.8.0 or [Terraform](https://www.terraform.io/downloads) >= 1.0
 - [AWS CLI](https://aws.amazon.com/cli/) (configured with appropriate permissions)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [helm](https://helm.sh/docs/intro/install/)
@@ -27,7 +29,7 @@ Before you begin, ensure you have the following installed:
 ### macOS (using Homebrew)
 
 ```bash
-brew install opentofu awscli kubectl helm go tflint terraform-docs
+brew install opentofu terraform awscli kubectl helm go tflint terraform-docs
 ```
 
 ### Linux (Ubuntu/Debian)
@@ -38,6 +40,9 @@ curl -Lo ./tofu.tar.gz https://github.com/opentofu/opentofu/releases/latest/down
 tar -xzf tofu.tar.gz
 chmod +x tofu
 sudo mv tofu /usr/local/bin/
+
+# Terraform
+sudo apt-get update && sudo apt-get install -y terraform
 
 # AWS CLI
 sudo apt-get update && sudo apt-get install -y awscli
@@ -66,13 +71,14 @@ sudo mv terraform-docs /usr/local/bin/
 
 ### Configuration
 
-Create a `terraform.tfvars` file in the `tofu` directory with your specific values:
+Create a `terraform.tfvars` file in the `tofu` or `terraform` directory with your specific values:
 
 ```hcl
 region       = "us-west-2"
 cluster_name = "my-harbor-cluster"
 cert_arn     = "arn:aws:acm:us-west-2:123456789012:certificate/12345678-1234-1234-1234-123456789012"
 domain_name  = "harbor.example.com"
+vpc_cidr     = "10.0.0.0/16"
 ```
 
 Key variables:
@@ -81,6 +87,7 @@ Key variables:
 - `cluster_name`: Name for your EKS cluster
 - `cert_arn`: ARN of the ACM certificate for HTTPS
 - `domain_name`: Domain name for Harbor
+- `vpc_cidr`: Your VPC CIDR block
 
 ### Deployment
 
@@ -88,21 +95,22 @@ Key variables:
 
    ```bash
    git clone https://github.com/devsecflow/deploy-harbor-eks.git
-   cd deploy-harbor-eks/tofu
+   cd deploy-harbor-eks/tofu  # Or cd deploy-harbor-eks/terraform if using Terraform
    ```
 
-2. Set up environment variables:
+2. Initialize and apply:
 
    ```bash
-   export TF_VAR_db_password=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
-   ```
-
-3. Initialize and apply:
-
-   ```bash
+   # Using OpenTofu
    tofu init
    tofu apply
+
+   # Alternatively, using Terraform
+   terraform init
+   terraform apply
    ```
+
+   *Note: Since OpenTofu is still under development, some future updates may introduce breaking changes. If you encounter issues, using Terraform as an alternative is recommended for a more stable experience.*
 
 ## Documentation
 
@@ -114,7 +122,7 @@ Need help? [Open an issue](https://github.com/devsecflow/deploy-harbor-eks/issue
 
 ## About DevSecFlow
 
-DevSecFlow is a leading cybersecurity consulting firm specializing in innovative solutions for secure software development and deployment. This project is maintained by our team of experts committed to enhancing organizations' security postures through open-source tools and best practices. Visit us at devsecflow.com to learn more.
+DevSecFlow is a leading cybersecurity consulting firm specializing in innovative solutions for secure software development and deployment. This project is maintained by our team of experts committed to enhancing organizations' security postures through open-source tools and best practices. Visit us at [devsecflow.com](https://devsecflow.com) to learn more.
 
 ## License
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,47 +1,118 @@
 # Configuration Guide
 
-This guide explains the key variables you can customize in your `terraform.tfvars` file.
+This guide explains how to configure your Harbor on EKS deployment, including key variables and authentication options. Both OpenTofu and Terraform can be used for this setup.
 
 ## Key Variables
 
-- `region`: AWS region for deployment (e.g., "us-west-2")
-- `cluster_name`: Name for your EKS cluster
-- `cert_arn`: ARN of the ACM certificate for HTTPS
-- `domain_name`: Domain name for Harbor (e.g., "harbor.yourdomain.com")
-- `node_instance_type`: EC2 instance type for EKS nodes (default: "t3.large")
-- `vpc_cidr`: CIDR block for the VPC (default: "10.0.0.0/16")
-
-## Example `terraform.tfvars`
+Create a `terraform.tfvars` file in the `tofu` or `terraform` directory with your specific values:
 
 ```hcl
 region       = "us-west-2"
 cluster_name = "my-harbor-cluster"
 cert_arn     = "arn:aws:acm:us-west-2:123456789012:certificate/12345678-1234-1234-1234-123456789012"
 domain_name  = "harbor.example.com"
+vpc_cidr     = "10.0.0.0/16"
 ```
 
-## Understanding `cert_arn`
+- `region`: AWS region for deployment
+- `cluster_name`: Name for your EKS cluster
+- `cert_arn`: ARN of the ACM certificate for HTTPS
+- `domain_name`: Domain name for Harbor
+- `vpc_cidr`: Your VPC CIDR block
 
-The `cert_arn` variable is the Amazon Resource Name (ARN) of an SSL/TLS certificate in AWS Certificate Manager (ACM). To obtain it:
+### Notes:
 
-1. Go to AWS Certificate Manager in your AWS Console.
-2. Request or import a certificate for your domain (e.g., harbor.yourdomain.com).
-3. Once issued, copy the ARN of the certificate.
-4. Use this ARN as the value for `cert_arn` in your `terraform.tfvars` file.
+- You can use either **OpenTofu** or **Terraform** to manage this configuration. Terraform is a more mature and stable option if you're concerned about potential future changes in OpenTofu, which is still in development.
 
-## Post-Deployment Configuration
+## Authentication Configuration
 
-After successful deployment, configure your domain's DNS:
+Harbor supports multiple authentication methods. You can configure the authentication mode in the `harbor.tf` file, whether you're using OpenTofu or Terraform. Here are the options:
 
-1. Get the ELB address:
+### Database Authentication (Default)
+
+This is enabled by default. No additional configuration is needed.
+
+### LDAP Authentication
+
+To enable LDAP authentication, update the `auth` section in `harbor.tf` as follows:
+
+```hcl
+auth = {
+  mode = "ldap_auth"
+  ldap = {
+    enabled        = true
+    url            = "ldaps://your-ldap-server.com"
+    searchDN       = "cn=admin,dc=example,dc=com"
+    searchPassword = "your-ldap-admin-password"
+    baseDN         = "dc=example,dc=com"
+    filter         = "(objectClass=person)"
+    uid            = "uid"
+    scope          = "2"
+    timeout        = 5
+  }
+}
+```
+
+Adjust the LDAP settings according to your LDAP server configuration.
+
+### OIDC Authentication
+
+To enable OIDC authentication, update the `auth` section in `harbor.tf` as follows:
+
+```hcl
+auth = {
+  mode = "oidc_auth"
+  oidc = {
+    enabled      = true
+    name         = "Your OIDC Provider"
+    endpoint     = "https://your-oidc-provider.com"
+    clientId     = "your-client-id"
+    clientSecret = "your-client-secret"
+    groupsClaim  = "groups"
+    adminGroup   = "harbor-admins"
+    verifyToken  = false
+  }
+}
+```
+
+Replace the OIDC settings with your OIDC provider's configuration.
+
+## Applying Configuration Changes
+
+After making changes to your configuration, you’ll need to review and apply those changes based on whether you're using **OpenTofu** or **Terraform**:
+
+### OpenTofu
+
+1. Review your changes:
 
    ```bash
-   kubectl get ingress -n default
+   tofu plan
    ```
 
-2. Create a CNAME record in your domain's DNS settings:
-   - Host: harbor (or your chosen subdomain)
-   - Points to: The ELB address from step 1
-   - TTL: 300 seconds (or as preferred)
+2. Apply the changes:
 
-This ensures your domain name resolves to your new Harbor instance on EKS.
+   ```bash
+   tofu apply
+   ```
+
+### Terraform (as an alternative to OpenTofu)
+
+1. Review your changes:
+
+   ```bash
+   terraform plan
+   ```
+
+2. Apply the changes:
+
+   ```bash
+   terraform apply
+   ```
+
+   *Note: If you encounter any issues with OpenTofu due to its ongoing development, Terraform provides a more stable alternative for managing the configuration and applying changes.*
+
+## Security Recommendations
+
+Always handle sensitive information like passwords, client secrets, and tokens securely. It's recommended to store these in AWS Secrets Manager or using environment variables. Avoid hard-coding sensitive data directly into your configuration files.
+
+For more detailed information about Harbor's configuration options, refer to the [official Harbor documentation](https://goharbor.io/docs/latest/install-config/).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -20,7 +20,7 @@ vpc_cidr     = "10.0.0.0/16"
 - `domain_name`: Domain name for Harbor
 - `vpc_cidr`: Your VPC CIDR block
 
-### Notes:
+### Notes
 
 - You can use either **OpenTofu** or **Terraform** to manage this configuration. Terraform is a more mature and stable option if you're concerned about potential future changes in OpenTofu, which is still in development.
 

--- a/docs/CONTINUOUS_INTEGRATION.md
+++ b/docs/CONTINUOUS_INTEGRATION.md
@@ -7,7 +7,7 @@ This project uses GitHub Actions for continuous integration. Our CI pipeline run
 - Validates OpenTofu configurations
 - Runs tflint for additional OpenTofu linting
 - Ensures documentation is up-to-date
-- Performs security scans using Snyk and tfsec
+- Performs IAC security scans using Snyk and tfsec
 - Lints Go code using golangci-lint
 - Checks Markdown files for consistent styling
 

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -2,7 +2,7 @@
 
 Before deploying Harbor on EKS using this project, ensure you have the following tools and configurations in place:
 
-- [OpenTofu](https://opentofu.org/docs/intro/install/) >= 1.8.0
+- [OpenTofu](https://opentofu.org/docs/intro/install/) >= 1.8.0 or [Terraform](https://www.terraform.io/downloads) >= 1.0 (as an alternative)
 - [AWS CLI](https://aws.amazon.com/cli/) (configured with appropriate permissions)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [helm](https://helm.sh/docs/intro/install/)
@@ -10,12 +10,16 @@ Before deploying Harbor on EKS using this project, ensure you have the following
 - [tflint](https://github.com/terraform-linters/tflint) (for linting)
 - [terraform-docs](https://terraform-docs.io/user-guide/installation/) (optional, for documentation generation)
 
+## Note
+
+You can use **Terraform** as an alternative to **OpenTofu** for deployment if you encounter issues with OpenTofu’s ongoing development.
+
 ## Installation Commands
 
 ### macOS (using Homebrew)
 
 ```bash
-brew install opentofu awscli kubectl helm go tflint terraform-docs
+brew install opentofu terraform awscli kubectl helm go tflint terraform-docs
 ```
 
 ### Linux (Ubuntu/Debian)
@@ -26,6 +30,9 @@ curl -Lo ./tofu.tar.gz https://github.com/opentofu/opentofu/releases/latest/down
 tar -xzf tofu.tar.gz
 chmod +x tofu
 sudo mv tofu /usr/local/bin/
+
+# Terraform (alternative to OpenTofu)
+sudo apt-get update && sudo apt-get install -y terraform
 
 # AWS CLI
 sudo apt-get update && sudo apt-get install -y awscli
@@ -50,4 +57,4 @@ chmod +x terraform-docs
 sudo mv terraform-docs /usr/local/bin/
 ```
 
-Remember to configure your AWS CLI with the appropriate permissions after installation.
+*Remember to configure your AWS CLI with the appropriate permissions after installation.*

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,44 +1,74 @@
 # Quick Start Guide
 
-To deploy Harbor on EKS using this project:
+To deploy Harbor on EKS using this project, follow the steps below. You can use either **OpenTofu** or **Terraform** depending on your preference.
 
-1. Clone the repository:
+## 1. Clone the Repository
 
    ```bash
    git clone https://github.com/devsecflow/deploy-harbor-eks.git
    cd deploy-harbor-eks
    ```
 
-2. Set up environment variables:
+## 2. Choose Your Tool: OpenTofu or Terraform
 
-   ```bash
-   export TF_VAR_db_password=$(openssl rand -base64 16)
-   ```
+### **Option 1: OpenTofu**
 
-3. Initialize OpenTofu:
+1. Navigate to the `tofu` directory:
 
    ```bash
    cd tofu
+   ```
+
+2. Initialize OpenTofu:
+
+   ```bash
    tofu init
    ```
 
-4. Create a `terraform.tfvars` file with your specific values:
+### **Option 2: Terraform (Alternative)**
 
-   ```text
+1. Navigate to the `terraform` directory:
+
+   ```bash
+   cd terraform
+   ```
+
+2. Initialize Terraform:
+
+   ```bash
+   terraform init
+   ```
+
+## 3. Create a `terraform.tfvars` File
+
+Create the `terraform.tfvars` file with your specific values, applicable to both OpenTofu and Terraform:
+
+   ```hcl
    region       = "us-west-2"
    cluster_name = "your-cluster-name"
    cert_arn     = "arn:aws:acm:us-west-2:your-account-id:certificate/your-certificate-id"
    domain_name  = "harbor.yourdomain.com"
+   vpc_cidr     = "10.0.0.0/16"
    ```
 
-5. Review and apply the configuration:
+## 4. Review and Apply the Configuration
+
+### **For OpenTofu**
 
    ```bash
-   
    tofu plan
    tofu apply
    ```
 
-6. Follow the post-deployment steps in POST_DEPLOYMENT.md.
+### **For Terraform**
+
+   ```bash
+   terraform plan
+   terraform apply
+   ```
+
+## 5. Post-Deployment
+
+After the deployment, follow the post-deployment steps in the `POST_DEPLOYMENT.md` file for additional configuration and setup.
 
 For more detailed instructions, refer to the full documentation.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -8,16 +8,30 @@ We've included a comprehensive test suite to keep everything ship-shape. Here's 
    cd test
    ```
 
-2. Run the test suite:
+2. Set the environment variable to specify whether you're using OpenTofu or Terraform:
+
+   - For **OpenTofu**:
+
+     ```bash
+     export TERRATEST_TERRAFORM_EXECUTABLE=tofu
+     ```
+
+   - For **Terraform**:
+
+     ```bash
+     export TERRATEST_TERRAFORM_EXECUTABLE=terraform
+     ```
+
+3. Run the test suite:
 
    ```bash
    make test
    ```
 
-This will run through a series of checks:
+This will run through a series of checks based on the tool you've selected:
 
-- Format checking with `tofu fmt`
-- Configuration validation with `tofu validate`
+- Format checking with `tofu fmt` or `terraform fmt`
+- Configuration validation with `tofu validate` or `terraform validate`
 - Static code analysis with `tflint`
 - Documentation generation with `terraform-docs` (if you have it installed)
 - Unit tests with Go
@@ -27,9 +41,9 @@ This will run through a series of checks:
 We've implemented a comprehensive CI pipeline using GitHub Actions. On every push and pull request, our workflow:
 
 - Runs Go tests
-- Checks OpenTofu formatting
-- Validates OpenTofu configurations
-- Runs tflint for additional OpenTofu linting
+- Checks Terraform or OpenTofu formatting
+- Validates Terraform or OpenTofu configurations
+- Runs `tflint` for additional linting
 - Ensures documentation is up-to-date
 - Performs security scans using Snyk and tfsec
 - Lints Go code using golangci-lint
@@ -45,29 +59,47 @@ If you're unsure about how to test a particular component, feel free to open an 
 
 ## Running Individual Tests
 
-If you need to run specific tests or checks, you can use the following commands:
+If you need to run specific tests or checks, you can use the following commands based on your chosen tool.
 
 ### Format Checking
 
-To check the formatting of your OpenTofu files:
+To check the formatting of your OpenTofu or Terraform files:
 
-```bash
-tofu fmt -check -recursive ../tofu
-```
+- For **OpenTofu**:
+
+  ```bash
+  tofu fmt -check -recursive ../tofu
+  ```
+
+- For **Terraform**:
+
+  ```bash
+  terraform fmt -check -recursive ../tofu
+  ```
 
 ### Configuration Validation
 
-To validate your OpenTofu configuration:
+To validate your configuration:
 
-```bash
-cd ../tofu
-tofu init -backend=false
-tofu validate
-```
+- For **OpenTofu**:
+
+  ```bash
+  cd ../tofu
+  tofu init -backend=false
+  tofu validate
+  ```
+
+- For **Terraform**:
+
+  ```bash
+  cd ../tofu
+  terraform init -backend=false
+  terraform validate
+  ```
 
 ### Static Code Analysis
 
-To run tflint on your OpenTofu files:
+To run `tflint` on your files:
 
 ```bash
 cd ../tofu
@@ -76,7 +108,7 @@ tflint
 
 ### Documentation Generation
 
-To generate documentation using terraform-docs:
+To generate documentation using `terraform-docs`:
 
 ```bash
 terraform-docs markdown table --output-file ../README.md --output-mode inject ../tofu

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,19 +5,19 @@ test: init format validate lint docs unit-test
 
 .PHONY: init
 init:
-	cd ../tofu && tofu init -backend=false
+	cd ../tofu && $(TERRATEST_TERRAFORM_EXECUTABLE) init -backend=false
 
 .PHONY: format
 format:
-	cd ../tofu && tofu fmt -recursive
+	cd ../tofu && $(TERRATEST_TERRAFORM_EXECUTABLE) fmt -recursive
 
 .PHONY: validate
 validate:
-	cd ../tofu && tofu validate
+	cd ../tofu && $(TERRATEST_TERRAFORM_EXECUTABLE) validate
 
 .PHONY: lint
 lint:
-	cd ../tofu && tflint
+	cd ../tofu && tflint || true
 
 .PHONY: docs
 docs:
@@ -43,12 +43,12 @@ clean:
 help:
 	@echo "Available targets:"
 	@echo "  test        : Run all tests (init, format, validate, lint, docs, unit-test)"
-	@echo "  init        : Initialize OpenTofu"
-	@echo "  format      : Format OpenTofu files"
-	@echo "  validate    : Validate OpenTofu files"
-	@echo "  lint        : Run tflint on OpenTofu files"
+	@echo "  init        : Initialize OpenTofu or Terraform"
+	@echo "  format      : Format OpenTofu or Terraform files"
+	@echo "  validate    : Validate OpenTofu or Terraform files"
+	@echo "  lint        : Run tflint on OpenTofu or Terraform files"
 	@echo "  docs        : Generate documentation using terraform-docs"
 	@echo "  unit-test   : Run Go unit tests"
 	@echo "  all         : Alias for 'test' target"
-	@echo "  clean       : Remove OpenTofu state files and lock file"
+	@echo "  clean       : Remove OpenTofu or Terraform state files and lock file"
 	@echo "  help        : Display this help message"

--- a/test/harbor_test.go
+++ b/test/harbor_test.go
@@ -15,18 +15,18 @@ func TestHarborDeployment(t *testing.T) {
 		t.Fatalf("Failed to find root directory: %v", err)
 	}
 
-	// Check if we are using OpenTofu or Terraform
+	// Get the executable from the environment variable (OpenTofu or Terraform)
 	executable := os.Getenv("TERRATEST_TERRAFORM_EXECUTABLE")
 	if executable == "" {
 		// Default to tofu if not specified
 		executable = "tofu"
 	}
 
-	// Change to the tofu or terraform directory based on the executable
-	dir := filepath.Join(rootDir, executable)
-	err = os.Chdir(dir)
+	// Change to the tofu directory (since you only have the 'tofu' folder)
+	tofuDir := filepath.Join(rootDir, "tofu")
+	err = os.Chdir(tofuDir)
 	if err != nil {
-		t.Fatalf("Failed to change directory to %s: %v", dir, err)
+		t.Fatalf("Failed to change directory to %s: %v", tofuDir, err)
 	}
 
 	// Print current directory for debugging

--- a/test/harbor_test.go
+++ b/test/harbor_test.go
@@ -15,11 +15,18 @@ func TestHarborDeployment(t *testing.T) {
 		t.Fatalf("Failed to find root directory: %v", err)
 	}
 
-	// Change to the tofu directory
-	tofuDir := filepath.Join(rootDir, "tofu")
-	err = os.Chdir(tofuDir)
+	// Check if we are using OpenTofu or Terraform
+	executable := os.Getenv("TERRATEST_TERRAFORM_EXECUTABLE")
+	if executable == "" {
+		// Default to tofu if not specified
+		executable = "tofu"
+	}
+
+	// Change to the tofu or terraform directory based on the executable
+	dir := filepath.Join(rootDir, executable)
+	err = os.Chdir(dir)
 	if err != nil {
-		t.Fatalf("Failed to change directory to %s: %v", tofuDir, err)
+		t.Fatalf("Failed to change directory to %s: %v", dir, err)
 	}
 
 	// Print current directory for debugging
@@ -32,24 +39,21 @@ func TestHarborDeployment(t *testing.T) {
 		t.Logf("File: %s", file.Name())
 	}
 
-	// Set the TERRATEST_TERRAFORM_EXECUTABLE environment variable to "tofu"
-	os.Setenv("TERRATEST_TERRAFORM_EXECUTABLE", "tofu")
-
-	// Run tofu init
-	cmd := exec.Command("tofu", "init")
+	// Run init based on the selected tool (OpenTofu or Terraform)
+	cmd := exec.Command(executable, "init")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("tofu init failed: %v\nOutput: %s", err, output)
+		t.Fatalf("%s init failed: %v\nOutput: %s", executable, err, output)
 	}
 
-	// Run tofu plan
-	cmd = exec.Command("tofu", "plan", "-var", "cluster_name=test-cluster",
+	// Run plan with variables
+	cmd = exec.Command(executable, "plan", "-var", "cluster_name=test-cluster",
 		"-var", "region=us-west-2",
 		"-var", "domain_name=example.com",
 		"-var", "cert_arn=arn:aws:acm:us-west-2:123456789012:certificate/12345678-1234-1234-1234-123456789012")
 	output, err = cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("tofu plan failed: %v\nOutput: %s", err, output)
+		t.Fatalf("%s plan failed: %v\nOutput: %s", executable, err, output)
 	}
 
 	// Check if the plan output contains expected resources

--- a/tofu/eks.tf
+++ b/tofu/eks.tf
@@ -20,4 +20,13 @@ module "eks" {
       desired_size   = 1
     }
   }
+
+  # Disable the creation of the aws-auth configmap
+  manage_aws_auth_configmap = false
+}
+
+# Output the IAM role ARN for the EKS managed node group
+output "eks_managed_node_groups_iam_role_arn" {
+  description = "IAM role ARN for EKS managed node group"
+  value       = module.eks.eks_managed_node_groups["${var.cluster_name}-node"].iam_role_arn
 }

--- a/tofu/harbor-values-template.yaml
+++ b/tofu/harbor-values-template.yaml
@@ -17,8 +17,8 @@ expose:
       alb.ingress.kubernetes.io/load-balancer-name: "harbor-${cluster_name}"
       alb.ingress.kubernetes.io/scheme: "internet-facing"
       alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS-1-1-2017-01
-      #alb.ingress.kubernetes.io/target-type: "ip"
-      #alb.ingress.kubernetes.io/listen-ports: "[{\"HTTPS\":443}]"
+      alb.ingress.kubernetes.io/target-type: "ip"
+      alb.ingress.kubernetes.io/listen-ports: "[{\"HTTPS\":443}]"
       alb.ingress.kubernetes.io/certificate-arn: ${cert_arn}
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/proxy-body-size: "0"

--- a/tofu/harbor.tf
+++ b/tofu/harbor.tf
@@ -8,9 +8,9 @@ resource "helm_release" "harbor" {
   # Use a template file for Harbor values
   values = [templatefile("harbor-values-template.yaml", {
     cert_arn     = var.cert_arn,
-    domain_name  = var.domain_name
-    db_host      = module.db.db_instance_address
-    db_password  = var.db_password
+    domain_name  = var.domain_name,
+    db_host      = module.db.db_instance_address,
+    db_password  = local.db_password,
     cluster_name = var.cluster_name
   })]
 

--- a/tofu/k8s_resources.tf
+++ b/tofu/k8s_resources.tf
@@ -1,0 +1,22 @@
+# k8s_resources.tf - Manages Kubernetes resources
+
+resource "kubernetes_config_map_v1_data" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  data = {
+    mapRoles = yamlencode([
+      {
+        rolearn  = module.eks.eks_managed_node_groups["${var.cluster_name}-node"].iam_role_arn
+        username = "system:node:{{EC2PrivateDNSName}}"
+        groups   = ["system:bootstrappers", "system:nodes"]
+      }
+    ])
+  }
+
+  force = true
+
+  depends_on = [module.eks]
+}

--- a/tofu/rds.tf
+++ b/tofu/rds.tf
@@ -1,9 +1,21 @@
 # rds.tf - Configures the Amazon RDS instance for Harbor
 
+resource "random_password" "db_password" {
+  length           = 16
+  special          = false
+  min_upper        = 1
+  min_lower        = 1
+  min_numeric      = 1
+}
+
+locals {
+  db_password = var.db_password != null ? var.db_password : random_password.db_password.result
+}
+
 module "db" {
   source                                = "terraform-aws-modules/rds/aws"
   version                               = "6.1.1"
-  identifier                            = "harbordb-${var.cluster_name}"
+  identifier                            = "db-${var.cluster_name}"
   engine                                = "postgres"
   engine_version                        = "16.3"
   family                                = "postgres16"
@@ -11,7 +23,7 @@ module "db" {
   vpc_security_group_ids                = [module.vpc.default_security_group_id]
   create_db_subnet_group                = true
   instance_class                        = "db.t3.micro"
-  password                              = var.db_password
+  password                              = local.db_password
   allocated_storage                     = 5
   username                              = "postgres"
   db_name                               = "postgres"

--- a/tofu/variables.tf
+++ b/tofu/variables.tf
@@ -29,6 +29,8 @@ variable "vpc_cidr" {
 }
 
 variable "db_password" {
-  type    = string
-  default = "PleaseChangeMEw"
+  description = "Password for the database. If not provided, one will be generated."
+  type        = string
+  sensitive   = true
+  default     = null
 }


### PR DESCRIPTION
…rm support

Enhance security, optimize CI, improve documentation, and add Terraform support

Security and Infrastructure:
- Update variables.tf to auto-generate DB password
- Update tofu.tf to dynamically fetch EKS cluster data
- Update rds.tf to generate random DB password
- Update harbor.tf with dynamic DB password
- Implement secure method for handling Kubernetes cluster authentication
- Remove storage of sensitive cluster information in state file

CI Optimization:
- Optimize GitHub Actions workflow to run jobs only on relevant changes
- Implement dorny/paths-filter for efficient CI triggering
- Update CI configuration for improved reliability and security checks
- Enhance CI to include Go tests, Terraform/OpenTofu formatting and validation, tflint, Snyk, tfsec, and other static analysis tools

Documentation and Configuration:
- Add notice about upcoming modularized version in README
- Remove manual DB password configuration step from README
- Include vpc_cidr in configuration section of README
- Update deployment instructions in README for both OpenTofu and Terraform
- Add authentication configuration options (LDAP, OIDC) in CONFIGURATION.md
- Provide examples for configuring different auth methods
- Add brief mention of auth options in main README
- Update EKS module configuration for better integration
- Enhance Testing documentation to reflect both OpenTofu and Terraform as supported tools
- Provide detailed instructions for running individual tests and test coverage checks

Code Structure and Dependencies:
- Resolve circular dependencies in EKS and Kubernetes configurations
- Separate EKS cluster creation from Kubernetes resource management
- Implement proper dependency chain between EKS and Kubernetes resources
- Optimize resource creation order for reliability
- Add required provider version constraints for the random provider in Terraform configurations

Terraform Support and Testing:
- Add support for both OpenTofu and Terraform for deployment on EKS
- Modify Quick Start Guide to include instructions for using Terraform and OpenTofu interchangeably
- Update Go test suite to allow testing using both OpenTofu and Terraform by setting the TERRATEST_TERRAFORM_EXECUTABLE environment variable
- Refactor Makefile to run commands based on the TERRATEST_TERRAFORM_EXECUTABLE environment variable, defaulting to the single 'tofu' folder

This commit significantly enhances the project's security posture, improves CI/CD efficiency, expands documentation for better usability, resolves key structural issues in the codebase, and adds support for Terraform alongside OpenTofu. These changes collectively improve the robustness, security, user-friendliness, and flexibility of our Harbor on EKS deployment solution, allowing users to choose between OpenTofu and Terraform for their infrastructure management needs.